### PR TITLE
fix timezone env TZ

### DIFF
--- a/open-webui/functions/run_code.py
+++ b/open-webui/functions/run_code.py
@@ -1114,7 +1114,6 @@ class Sandbox:
                 "SHLVL=1",
                 "TERM=xterm",
                 "USER=user",
-                "TZ=" + time.tzname[0],
             ],
             "cwd": "/home/user",
             "capabilities": {
@@ -2592,6 +2591,9 @@ class Sandbox:
         """
         # Set up basic configuration options.
         oci_config = copy.deepcopy(self.OCI_CONFIG_SKELETON)
+        tz = os.environ.get("TZ")
+        if tz:
+            oci_config["process"]["env"].append(f"TZ={tz}")
         if self._max_ram_bytes:
             oci_config["linux"]["resources"]["memory"]["limit"] = self._max_ram_bytes
         os.makedirs(self._bundle_path, mode=0o711)

--- a/open-webui/tools/run_code.py
+++ b/open-webui/tools/run_code.py
@@ -553,7 +553,6 @@ class Sandbox:
                 "SHLVL=1",
                 "TERM=xterm",
                 "USER=user",
-                "TZ=" + time.tzname[0],
             ],
             "cwd": "/home/user",
             "capabilities": {
@@ -2031,6 +2030,9 @@ class Sandbox:
         """
         # Set up basic configuration options.
         oci_config = copy.deepcopy(self.OCI_CONFIG_SKELETON)
+        tz = os.environ.get("TZ")
+        if tz:
+            oci_config["process"]["env"].append(f"TZ={tz}")
         if self._max_ram_bytes:
             oci_config["linux"]["resources"]["memory"]["limit"] = self._max_ram_bytes
         os.makedirs(self._bundle_path, mode=0o711)

--- a/src/safecode/sandbox.py
+++ b/src/safecode/sandbox.py
@@ -112,7 +112,6 @@ class Sandbox:
                 "SHLVL=1",
                 "TERM=xterm",
                 "USER=user",
-                "TZ=" + time.tzname[0],
             ],
             "cwd": "/home/user",
             "capabilities": {
@@ -1590,6 +1589,9 @@ class Sandbox:
         """
         # Set up basic configuration options.
         oci_config = copy.deepcopy(self.OCI_CONFIG_SKELETON)
+        tz = os.environ.get("TZ")
+        if tz:
+            oci_config["process"]["env"].append(f"TZ={tz}")
         if self._max_ram_bytes:
             oci_config["linux"]["resources"]["memory"]["limit"] = self._max_ram_bytes
         os.makedirs(self._bundle_path, mode=0o711)


### PR DESCRIPTION
For e.g, with $TZ="Asia/Chongqing" on host

"TZ=" + time.tzname[0]

will set TZ=CST, which restult in utils such as 'date' output UTC time instead of CST time because "CST" isn't a valid timezone.

This fix just forwards the $TZ to givsor environment only if it is set on host.